### PR TITLE
[TAS-80] feature: bottomNavigationBar

### DIFF
--- a/lib/common/screens/root_tab.dart
+++ b/lib/common/screens/root_tab.dart
@@ -1,17 +1,91 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/common/layouts/default_layout.dart';
+import 'package:frontend/custom_map/screens/bottom_navigation_test_screen.dart';
 
-class RootTab extends StatelessWidget {
+class RootTab extends StatefulWidget {
   const RootTab({super.key});
 
   @override
+  State<RootTab> createState() => _RootTabState();
+}
+
+class _RootTabState extends State<RootTab> with SingleTickerProviderStateMixin {
+  late TabController tabController;
+  int bottomNavigationBarCurrentIndex = 1;
+
+  @override
+  void initState() {
+    super.initState();
+
+    tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: bottomNavigationBarCurrentIndex,
+    );
+
+    tabController.addListener(bottomNavigationBarTabListener);
+  }
+
+  void bottomNavigationBarTabListener() {
+    setState(() {
+      bottomNavigationBarCurrentIndex = tabController.index;
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    tabController.removeListener(bottomNavigationBarTabListener);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const DefaultLayout(
-      child: Center(
-        child: Text(
-          'Root Tab',
-        ),
+    return DefaultLayout(
+      title: 'Zeppy',
+      bottomNavigationBar: BottomNavigationBar(
+        selectedItemColor: Colors.black,
+        unselectedItemColor: Colors.grey,
+        selectedFontSize: 12.0,
+        unselectedFontSize: 12.0,
+        type: BottomNavigationBarType.fixed,
+        onTap: (int selectedIndex) {
+          tabController.animateTo(
+            selectedIndex,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.ease,
+          );
+        },
+        currentIndex: bottomNavigationBarCurrentIndex,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.map_outlined,
+            ),
+            label: '지도',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.home_outlined,
+            ),
+            label: '홈',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(
+              Icons.person,
+            ),
+            label: '마이페이지',
+          ),
+        ],
       ),
+      child: TabBarView(
+          physics: const NeverScrollableScrollPhysics(),
+          controller: tabController,
+          children: [
+            BottomNavigationTestScreen(testScreenName: '지도 스크린'),
+            BottomNavigationTestScreen(testScreenName: '홈 스크린'),
+            BottomNavigationTestScreen(testScreenName: '마이페이지 스크린'),
+          ]),
     );
   }
 }

--- a/lib/custom_map/screens/bottom_navigation_test_screen.dart
+++ b/lib/custom_map/screens/bottom_navigation_test_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class BottomNavigationTestScreen extends StatelessWidget {
+  final String testScreenName;
+  const BottomNavigationTestScreen({
+    super.key,
+    required this.testScreenName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('테스트 전환 화면: $testScreenName'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/user/screens/login_screen.dart
+++ b/lib/user/screens/login_screen.dart
@@ -15,11 +15,11 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     void onKakaoLoginButtonClick() {
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => const RootTab(),
-        ),
-      );
+      Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(
+            builder: (_) => const RootTab(),
+          ),
+          (route) => false);
     }
 
     return DefaultLayout(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 디자인 변경
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/kakao-login -> develop
### 변경 사항
- 정상 로그인 이후 나오는 앱 메인 스크린에서 bottomNavationBar를 활용해 화면을 전환할 수 있도록 조정
### 테스트 결과 (optional)
- BottomNavigationBar가 붙어있는 상태. 아래 탭 누르면 동일한 DefalutLayout을 가진 상태에서 Screen만 전환
![image](https://github.com/SWM-AAA/frontend_flutter/assets/77617267/cab1fc80-f6d0-4749-98b3-352d29d497b9)